### PR TITLE
Update rules to utilize configurations per rule

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,13 +5,17 @@ name: Tests
 # yamllint disable-line rule:truthy
 on:
   - push
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
     strategy:
-      max-parallel: 5
+      max-parallel: 10
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        platform:
+          - ubuntu-latest
+          # - macos-latest
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,10 @@
 ansible
-ansible-lint
+# .. note::
+#    pr#1534 was merged into master but it takes some time that newer
+#    ansible-lint of which .rules.AnsibleLintRule has a method named get_config.
+#    So we need the git HEAD version instead of released ones.
+#
+# .. seealso:: https://github.com/ansible-community/ansible-lint/pull/1534
+#
+# ansible-lint
+-e git+https://github.com/ansible-community/ansible-lint@master#egg=ansible-lint

--- a/rules/BlockedModules.py
+++ b/rules/BlockedModules.py
@@ -31,50 +31,38 @@ variable, _ANSIBLE_LINT_RULE_BLOCKED_MODULES.
 
 .. seealso:: :class:`~ansiblielint.rules.DeprecatedModuleRule`
 """
-import functools
-import os
-import re
 import typing
 import warnings
 
 import ansiblelint.rules
 
+from ansiblelint.config import options as OPTIONS
 
-ID: str = 'blocked-modules'
-ENV_VAR = '_ANSIBLE_LINT_RULE_' + ID.upper().replace('-', '_')
 
-BLOCKED_MODULES: typing.FrozenSet[str] = frozenset("""
+ID: str = 'blocked_modules'
+C_BLOCKED_MODULES: str = 'blocked'
+
+DESC: str = """Rule to test if some blocked modules were used in tasks.
+
+- Options
+
+  - ``blocked`` lists the modules blocked to use
+
+- Configuration
+
+  .. code-block:: yaml
+
+  rules:
+    blocked_modules:
+      blocked:
+        - shell
+        - include
+"""
+
+BLOCKED_MODULES: typing.List[str] = """
 shell
 include
-""".split())
-
-MODULES_RE = re.compile(r'^(\w+(?:\s+\w+)*)$', re.ASCII)
-
-
-@functools.lru_cache()
-def blocked_modules(default: typing.FrozenSet[str] = BLOCKED_MODULES
-                    ) -> typing.FrozenSet[str]:
-    """
-    Get and return the blocked modules from the env. var, file or default.
-    """
-    blocked = os.environ.get(ENV_VAR, '')
-    if blocked:
-        if blocked.startswith('@'):  # It's a file path.
-            path = blocked[1:]
-            try:
-                res = frozenset(line.strip() for line in open(path)
-                                if line.strip() and not line.startswith('#'))
-                if res:
-                    return res
-            except (IOError, OSError) as exc:
-                warnings.warn('Failed to load blocked modules from '
-                              f'{path}, exc={exc!s}')
-        else:
-            match = MODULES_RE.match(blocked)
-            if match:
-                return frozenset(match.groups()[0].split())
-
-    return default
+""".split()
 
 
 class BlockedModules(ansiblelint.rules.AnsibleLintRule):
@@ -88,6 +76,27 @@ class BlockedModules(ansiblelint.rules.AnsibleLintRule):
     severity: str = 'HIGH'
     tags: typing.List[str] = [ID, 'module']
 
+    initialized: bool = False
+    _blocked: typing.FrozenSet[str] = frozenset(BLOCKED_MODULES)
+
+    def blocked_modules(self):
+        """
+        .. seealso:: rules.DebugRule.DebugRule.enabled
+        """
+        if self.initialized:
+            return self._blocked
+
+        config = getattr(OPTIONS, 'rules', {}).get(self.id, {})
+        try:
+            _blocked = config.get(C_BLOCKED_MODULES, BLOCKED_MODULES)
+            self._blocked = _blocked
+        except (TypeError, ValueError):
+            warnings.warn(f'Invalid value for frozenset: {_blocked!r}')
+
+        self.initialized = True
+
+        return self._blocked
+
     def matchtask(self, task: typing.Dict[str, typing.Any]
                   ) -> typing.Union[bool, str]:
         """
@@ -95,7 +104,7 @@ class BlockedModules(ansiblelint.rules.AnsibleLintRule):
         """
         try:
             mod = task['action']['__ansible_module__']
-            if mod in blocked_modules():
+            if mod in self.blocked_modules():
                 return f'{self.shortdesc}: {mod}'
         except KeyError:
             pass

--- a/rules/BlockedModules.py
+++ b/rules/BlockedModules.py
@@ -2,34 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 #
+# pylint: disable=invalid-name
 r"""
 Lint rule class to test if some blocked modules were used.
-
-Users can change the behavior of this rule by specifying a environment
-variable, _ANSIBLE_LINT_RULE_BLOCKED_MODULES.
-
-- An example to list blocked modules with the env. variable.
-
-  ::
-
-      _ANSIBLE_LINT_RULE_BLOCKED_MODULES="shell raw"
-
-- An example to list blocked modules with the file given in the env. variable.
-
-  ::
-
-      _ANSIBLE_LINT_RULE_BLOCKED_MODULES="@/tmp/mb.list"
-
-  The file must contain module names to be blocked line by line, and comments
-  in the file starts with '#' are ignored like this:
-
-  ::
-
-     # this is a comment line.
-     shell
-     include
-
-.. seealso:: :class:`~ansiblielint.rules.DeprecatedModuleRule`
 """
 import typing
 import warnings
@@ -57,6 +32,8 @@ DESC: str = """Rule to test if some blocked modules were used in tasks.
       blocked:
         - shell
         - include
+
+.. seealso:: :class:`~ansiblielint.rules.DeprecatedModuleRule`
 """
 
 BLOCKED_MODULES: typing.List[str] = """
@@ -72,7 +49,7 @@ class BlockedModules(ansiblelint.rules.AnsibleLintRule):
     """
     id: str = ID
     shortdesc: str = 'Blocked modules'
-    description: str = 'Use of the blocked modules are prohivited.'
+    description: str = DESC
     severity: str = 'HIGH'
     tags: typing.List[str] = [ID, 'module']
 

--- a/rules/BlockedModules.py
+++ b/rules/BlockedModules.py
@@ -20,7 +20,7 @@ variable, _ANSIBLE_LINT_RULE_BLOCKED_MODULES.
 
       _ANSIBLE_LINT_RULE_BLOCKED_MODULES="@/tmp/mb.list"
 
-  The file must contain module names to be blockeded line by line, and comments
+  The file must contain module names to be blocked line by line, and comments
   in the file starts with '#' are ignored like this:
 
   ::
@@ -40,7 +40,7 @@ import warnings
 import ansiblelint.rules
 
 
-ID: str = 'blockeded-modules'
+ID: str = 'blocked-modules'
 ENV_VAR = '_ANSIBLE_LINT_RULE_' + ID.upper().replace('-', '_')
 
 BLOCKED_MODULES: typing.FrozenSet[str] = frozenset("""
@@ -84,7 +84,7 @@ class BlockedModules(ansiblelint.rules.AnsibleLintRule):
     """
     id: str = ID
     shortdesc: str = 'Blocked modules'
-    description: str = 'Use of the blockeded modules are prohivited.'
+    description: str = 'Use of the blocked modules are prohivited.'
     severity: str = 'HIGH'
     tags: typing.List[str] = [ID, 'module']
 

--- a/rules/DebugRule.py
+++ b/rules/DebugRule.py
@@ -4,29 +4,35 @@
 # pylint: disable=invalid-name
 """ Lint rule class to Debug
 """
-import functools
-import os
 import typing
 
 import ansiblelint.errors
 import ansiblelint.file_utils
 import ansiblelint.rules
 
+from ansiblelint.config import options as OPTIONS
+
 if typing.TYPE_CHECKING:
     from ansiblelint.constants import odict
 
 
 ID: str = 'debug'
+C_ENABLED: str = 'enabled'
 
-ENABLE_THIS_RULE_ENVVAR = f'_ANSIBLE_LINT_RULE_{ID.upper()}'
+DESC: str = f"""Rule to debug and monitor ansible-lint behavior.
 
+- Options
 
-@functools.lru_cache()
-def is_enabled(default: bool = False) -> bool:
-    """
-    Is this rule enabled with the environment variable?
-    """
-    return bool(os.environ.get(ENABLE_THIS_RULE_ENVVAR, default))
+  - ``{C_ENABLED}`` enables this rule disabled by default.
+
+- Configuration
+
+  .. code-block:: yaml
+
+  rules:
+    {ID}:
+      {C_ENABLED}: true
+"""
 
 
 class DebugRule(ansiblelint.rules.AnsibleLintRule):
@@ -34,22 +40,40 @@ class DebugRule(ansiblelint.rules.AnsibleLintRule):
     Lint rule class for debug.
     """
     id = ID
-    shortdesc = description = 'Debug ansible-lint objects'
+    shortdesc = 'Debug ansible-lint'
+    description = DESC
     severity = 'LOW'
     tags = ['debug']
+
+    initialized = False
+    _enabled = False
+
+    def enabled(self):
+        """
+        .. seealso:: ansiblelint.config.options
+        .. seealso:: ansiblelint.cli.load_config
+        """
+        if self.initialized:
+            return self._enabled
+
+        config = getattr(OPTIONS, 'rules', {}).get(self.id, {})
+        self._enabled = config.get(C_ENABLED, False)
+        self.initialized = True
+
+        return self._enabled
 
     def match(self, line: str) -> typing.Union[bool, str]:
         """
         .. seealso:: ansiblelint.rules.AnsibleLintRule.matchlines
         """
-        return f'match() at: {line}' if is_enabled() else False
+        return f'match() at: {line}' if self.enabled() else False
 
     def matchtask(self, task: typing.Dict[str, typing.Any]
                   ) -> typing.Union[bool, str]:
         """
         .. seealso:: ansiblelint.rules.AnsibleLintRule.matchtasks
         """
-        return f'matchtask(): {task!r}' if is_enabled() else False
+        return f'matchtask(): {task!r}' if self.enabled() else False
 
     def matchplay(self, file: ansiblelint.file_utils.Lintable,
                   data: 'odict[str, typing.Any]'
@@ -57,7 +81,7 @@ class DebugRule(ansiblelint.rules.AnsibleLintRule):
         """
         .. seealso:: ansiblelint.rules.AnsibleLintRule.matchtasks
         """
-        if is_enabled():
+        if self.enabled():
             msg = f'matchplay(): {file!r}, {data!r}'
             return [self.create_matcherror(message=msg, filename=file.name)]
 

--- a/rules/DebugRule.py
+++ b/rules/DebugRule.py
@@ -10,10 +10,10 @@ import ansiblelint.errors
 import ansiblelint.file_utils
 import ansiblelint.rules
 
-from ansiblelint.config import options as OPTIONS
-
 if typing.TYPE_CHECKING:
+    from typing import Optional
     from ansiblelint.constants import odict
+    from ansiblelint.file_utils import Lintable
 
 
 ID: str = 'debug'
@@ -45,35 +45,27 @@ class DebugRule(ansiblelint.rules.AnsibleLintRule):
     severity = 'LOW'
     tags = ['debug']
 
-    initialized = False
-    _enabled = False
-
+    @property
     def enabled(self):
         """
         .. seealso:: ansiblelint.config.options
         .. seealso:: ansiblelint.cli.load_config
         """
-        if self.initialized:
-            return self._enabled
-
-        config = getattr(OPTIONS, 'rules', {}).get(self.id, {})
-        self._enabled = config.get(C_ENABLED, False)
-        self.initialized = True
-
-        return self._enabled
+        return self.get_config(C_ENABLED)
 
     def match(self, line: str) -> typing.Union[bool, str]:
         """
         .. seealso:: ansiblelint.rules.AnsibleLintRule.matchlines
         """
-        return f'match() at: {line}' if self.enabled() else False
+        return f'match() at: {line}' if self.enabled else False
 
-    def matchtask(self, task: typing.Dict[str, typing.Any]
+    def matchtask(self, task: typing.Dict[str, typing.Any],
+                  file: 'Optional[Lintable]' = None
                   ) -> typing.Union[bool, str]:
         """
         .. seealso:: ansiblelint.rules.AnsibleLintRule.matchtasks
         """
-        return f'matchtask(): {task!r}' if self.enabled() else False
+        return f'matchtask(): {task!r}, {file!r}' if self.enabled else False
 
     def matchplay(self, file: ansiblelint.file_utils.Lintable,
                   data: 'odict[str, typing.Any]'
@@ -81,7 +73,7 @@ class DebugRule(ansiblelint.rules.AnsibleLintRule):
         """
         .. seealso:: ansiblelint.rules.AnsibleLintRule.matchtasks
         """
-        if self.enabled():
+        if self.enabled:
             msg = f'matchplay(): {file!r}, {data!r}'
             return [self.create_matcherror(message=msg, filename=file.name)]
 

--- a/rules/DebugRule.py
+++ b/rules/DebugRule.py
@@ -19,19 +19,19 @@ if typing.TYPE_CHECKING:
 ID: str = 'debug'
 C_ENABLED: str = 'enabled'
 
-DESC: str = f"""Rule to debug and monitor ansible-lint behavior.
+DESC: str = """Rule to debug and monitor ansible-lint behavior.
 
 - Options
 
-  - ``{C_ENABLED}`` enables this rule disabled by default.
+  - ``enabled`` enables this rule disabled by default.
 
 - Configuration
 
   .. code-block:: yaml
 
   rules:
-    {ID}:
-      {C_ENABLED}: true
+    debug:
+      enabled: true
 """
 
 

--- a/rules/LoopIsRecommendedRule.py
+++ b/rules/LoopIsRecommendedRule.py
@@ -8,8 +8,12 @@ import typing
 
 import ansiblelint.rules
 
+if typing.TYPE_CHECKING:
+    from typing import Optional
+    from ansiblelint.file_utils import Lintable
 
-ID: str = 'loop-is-recommended'
+
+ID: str = 'loop_is_recommended'
 DESC: str = """loop is recommended and use of with_* may be repalced with it.
 See also:
 https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html
@@ -27,6 +31,7 @@ class LoopIsRecommendedRule(ansiblelint.rules.AnsibleLintRule):
     tags: typing.List[str] = [ID, 'readability', 'formatting']
 
     def matchtask(self, task: typing.Dict[str, typing.Any],
+                  file: 'Optional[Lintable]' = None
                   ) -> typing.Union[bool, str]:
         """
         .. seealso:: ansiblelint.rules.AnsibleLintRule.matchtasks

--- a/tests/TestBlockedModules.py
+++ b/tests/TestBlockedModules.py
@@ -26,7 +26,7 @@ class Base:
      ('@/dev/null', TT.BLOCKED_MODULES),
      ]
 )
-def test_blockeded_modules(evalue, expected, monkeypatch):
+def test_blocked_modules(evalue, expected, monkeypatch):
     monkeypatch.setenv(TT.ENV_VAR, evalue)
     assert TT.blocked_modules() == expected
     Base.clear_fn()
@@ -39,7 +39,7 @@ def test_blockeded_modules(evalue, expected, monkeypatch):
      ('#\nping\nscript\n', frozenset(('ping', 'script'))),
      ]
 )
-def test_blockeded_modules_from_file(content, expected, tmp_path, monkeypatch):
+def test_blocked_modules_from_file(content, expected, tmp_path, monkeypatch):
     path = tmp_path / 'blocked_modules.list'
     path.write_text(content)
 

--- a/tests/TestBlockedModules.py
+++ b/tests/TestBlockedModules.py
@@ -13,6 +13,7 @@ from tests import common
 class Base:
     this_py: common.MaybeModNameT = __file__
     this_mod: common.MaybeModT = TT
+    rule_memoized = ['blocked_modules']
 
 
 class RuleTestCase(Base, common.RuleTestCase):

--- a/tests/TestBlockedModules.py
+++ b/tests/TestBlockedModules.py
@@ -6,8 +6,6 @@
 # pylint: disable=missing-function-docstring
 """Test cases for the rule, BlockedModules.
 """
-import pytest
-
 from rules import BlockedModules as TT
 from tests import common
 
@@ -15,54 +13,13 @@ from tests import common
 class Base:
     this_py: common.MaybeModNameT = __file__
     this_mod: common.MaybeModT = TT
-    clear_fn: common.MaybeCallableT = TT.blocked_modules.cache_clear
-
-
-@pytest.mark.parametrize(
-    'evalue,expected',
-    [('', TT.BLOCKED_MODULES),
-     ('ping', frozenset(('ping', ))),
-     ('ping script', frozenset(('ping', 'script'))),
-     ('@/dev/null', TT.BLOCKED_MODULES),
-     ]
-)
-def test_blocked_modules(evalue, expected, monkeypatch):
-    monkeypatch.setenv(TT.ENV_VAR, evalue)
-    assert TT.blocked_modules() == expected
-    Base.clear_fn()
-
-
-@pytest.mark.parametrize(
-    'content,expected',
-    [('#\n\n', TT.BLOCKED_MODULES),
-     ('ping\n', frozenset(('ping', ))),
-     ('#\nping\nscript\n', frozenset(('ping', 'script'))),
-     ]
-)
-def test_blocked_modules_from_file(content, expected, tmp_path, monkeypatch):
-    path = tmp_path / 'blocked_modules.list'
-    path.write_text(content)
-
-    monkeypatch.setenv(TT.ENV_VAR, f'@{path!s}')
-    assert TT.blocked_modules() == expected
-    Base.clear_fn()
-
-
-# 'ping' is listed in it.
-LIST_FILE = common.TESTS_DIR / 'res' / 'BlockedModules' / 'blocked_modules.txt'
 
 
 class RuleTestCase(Base, common.RuleTestCase):
-    def test_30_ng_cases__env(self):
-        self.lint(False, 'ok', env={TT.ENV_VAR: 'ping'})
-
-    def test_40_ng_cases__file(self):
-        self.lint(False, 'ok', env={TT.ENV_VAR: f'@{LIST_FILE!s}'})
+    def test_20_ng_cases(self):
+        self.lint(False, 'ok', config=dict(blocked=['ping']))
 
 
 class CliTestCase(Base, common.CliTestCase):
-    def test_30_ng_cases__env(self):
-        self.lint(False, 'ok', env={TT.ENV_VAR: 'ping'})
-
-    def test_40_ng_cases__file(self):
-        self.lint(False, 'ok', env={TT.ENV_VAR: f'@{LIST_FILE!s}'})
+    def test_20_ng_cases__env(self):
+        self.lint(False, 'ok', config=dict(blocked=['ping']))

--- a/tests/TestDebugRule.py
+++ b/tests/TestDebugRule.py
@@ -10,20 +10,16 @@ from rules import DebugRule as TT
 from tests import common
 
 
-_ENV_PATCH = {TT.ENABLE_THIS_RULE_ENVVAR: '1'}
-
-
 class Base:
     this_py: common.MaybeModNameT = __file__
     this_mod: common.MaybeModT = TT
-    clear_fn: common.MaybeCallableT = TT.is_enabled.cache_clear
 
 
 class RuleTestCase(Base, common.RuleTestCase):
     def test_20_ng_cases(self):
-        self.lint(False, subdir='ok', env=_ENV_PATCH)
+        self.lint(False, subdir='ok', config=dict(enabled=True))
 
 
 class CliTestCase(Base, common.CliTestCase):
     def test_20_ng_cases(self):
-        self.lint(False, subdir='ok', env=_ENV_PATCH)
+        self.lint(False, subdir='ok', config=dict(enabled=True))

--- a/tests/TestFileHasValidNameRule.py
+++ b/tests/TestFileHasValidNameRule.py
@@ -8,41 +8,47 @@
 """
 import pytest
 
+import ansiblelint.config
+
 from rules import FileHasValidNameRule as TT
 from tests import common
 
 
-_ENV_PATCH = {TT.ENV_VAR: "\\S+NEVER_MATCH"}
+NG_VALID_NAME_RE = r'\S+NEVER_MATCH'
 
 
 class Base:
     this_py: common.MaybeModNameT = __file__
     this_mod: common.MaybeModT = TT
-    clear_fn: common.MaybeCallableT = TT.filename_re.cache_clear
+    rule_memoized = ['is_valid_filename']
 
 
 @pytest.mark.parametrize(
-    'path,evalue,expected',
-    [('main.yml', '', True),
-     ('main-0.yml', '', False),
-     ('main .yml', '', False),
-     ('ng_１.yml', '', False),
-     ('ng-２.yml', '', False),
-     ('main-0.yml', r'\S+', True),
+    'path,name,unicode,expected',
+    [('main.yml', '', False, True),
+     ('main-0.yml', '', False, False),
+     ('main .yml', '', False, False),
+     ('ng_１.yml', '', False, False),
+     ('ng_１.yml', r'^\w+\.ya?ml$', True, True),
+     ('ng-２.yml', '', False, False),
+     ('main-0.yml', r'\S+', False, True),
      ]
 )
-def test_is_valid_filename(path, evalue, expected, monkeypatch):
-    if evalue:
-        monkeypatch.setenv(TT.ENV_VAR, evalue)
-    assert TT.is_valid_filename(path) == expected
-    Base.clear_fn()
+def test_is_valid_filename(path, name, unicode, expected, monkeypatch):
+    if name:
+        monkeypatch.setitem(
+            ansiblelint.config.options.rules, TT.ID,
+            dict(name=name, unicode=unicode)
+        )
+    rule = common.get_rule_instance_by_module(Base.this_py, Base.this_mod)
+    assert rule.is_valid_filename(path) == expected
 
 
 class RuleTestCase(Base, common.RuleTestCase):
-    def test_30_playbook_file_has_valid_name__ng(self):
-        self.lint(False, 'ok', env=_ENV_PATCH)
+    def test_30_ng_cases_by_config(self):
+        self.lint(False, 'ok', config=dict(name=NG_VALID_NAME_RE))
 
 
 class CliTestCase(Base, common.CliTestCase):
-    def test_30_ng_cases__env(self):
-        self.lint(False, 'ok', env=_ENV_PATCH)
+    def test_30_ng_cases_by_config(self):
+        self.lint(False, 'ok', config=dict(name=NG_VALID_NAME_RE))

--- a/tests/TestFileIsSmallEnoughRule.py
+++ b/tests/TestFileIsSmallEnoughRule.py
@@ -12,55 +12,30 @@ from rules import FileIsSmallEnoughRule as TT
 from tests import common
 
 
-@pytest.fixture(autouse=True)
-def cache_clear():
-    yield
-    TT.max_lines.cache_clear()
-
-
 @pytest.mark.parametrize(
-    'evalue,expected',
-    [('', TT.MAX_LINES),
-     ('aaa', TT.MAX_LINES),
-     ('0', TT.MAX_LINES),
-     ('1', 1),
-     ]
-)
-def test_max_lines(evalue, expected, monkeypatch):
-    monkeypatch.setenv(TT.ENV_VAR, evalue)
-    assert TT.max_lines() == expected
-
-
-@pytest.mark.parametrize(
-    'mlines,expected',
+    'max_lines,expected',
     [(100000, False),
      (1, True),
-     (0, False),  # default
      ]
 )
-def test_exceeds_max_lines(mlines, expected):
-    assert TT.exceeds_max_lines(__file__, mlines=mlines) == expected
-
-
-def test_exceeds_max_lines_with_env(monkeypatch):
-    monkeypatch.setenv(TT.ENV_VAR, '1')
-    assert TT.exceeds_max_lines(__file__)
+def test_exceeds_max_lines(max_lines, expected):
+    assert TT.exceeds_max_lines(__file__, max_lines) == expected
 
 
 class Base:
     this_py: common.MaybeModNameT = __file__
     this_mod: common.MaybeModT = TT
-    clear_fn: common.MaybeCallableT = TT.max_lines.cache_clear
+    rule_memoized = ['max_lines', 'exceeds_max_lines']
 
 
-_ENV_PATCH = {TT.ENV_VAR: '1'}
+CNF = dict(max_lines=1)
 
 
 class RuleTestCase(Base, common.RuleTestCase):
     def test_20_ng_cases(self):
-        self.lint(False, 'ok', env=_ENV_PATCH)
+        self.lint(False, 'ok', config=CNF)
 
 
 class CliTestCase(Base, common.CliTestCase):
     def test_20_ng_cases(self):
-        self.lint(False, 'ok', env=_ENV_PATCH)
+        self.lint(False, 'ok', config=CNF)

--- a/tests/TestTaskHasValidNameRule.py
+++ b/tests/TestTaskHasValidNameRule.py
@@ -6,42 +6,49 @@
 # pylint: disable=too-few-public-methods
 """Test cases for the rule, TaskHasValidNamePatternRule.
 """
-import re
-import typing
-
+import ansiblelint.config
 import pytest
 
 from rules import TaskHasValidNameRule as TT
 from tests import common
 
 
-_ENV_PATCH = {TT.ENV_VAR: r'\S+'}
-_NAME_RE_DEFAULT: typing.Pattern = re.compile(TT.NAME_RE, re.ASCII)
+VALID_NAME_0 = 'Ensure foo is installed'
+INVALID_NAME_0 = 'foo'
+NAME_RE_0 = r'^\S+$'
+
+CNF_0 = dict(name=NAME_RE_0)
 
 
 class Base:
     this_py: common.MaybeModNameT = __file__
     this_mod: common.MaybeModT = TT
-    clear_fn: common.MaybeCallableT = TT.task_name_pattern.cache_clear
+    rule_memoized = ['valid_name_re', 'is_invalid_task_name']
 
 
 @pytest.mark.parametrize(
-    'evalue,expected',
-    [('', TT.NAME_RE),
-     (r'\S \S+', TT.NAME_RE),  # invalid pattern
-     (r'\S+', r'\S+'),
+    'name,evalue,expected',
+    [(VALID_NAME_0, '', False),  # default.
+     (INVALID_NAME_0, '', True),
+     (VALID_NAME_0, r'NEVER_MATCH', True),
+     (VALID_NAME_0, NAME_RE_0, True),
+     (INVALID_NAME_0, NAME_RE_0, False),
      ]
 )
-def test_task_name_re(evalue, expected, monkeypatch):
-    monkeypatch.setenv(TT.ENV_VAR, evalue)
-    assert TT.name_re(TT.NAME_RE) == expected
+def test_is_invalid_task_name(name, evalue, expected, monkeypatch):
+    monkeypatch.setitem(
+        ansiblelint.config.options.rules, TT.ID,
+        dict(name=evalue)
+    )
+    rule = common.get_rule_instance_by_module(Base.this_py, Base.this_mod)
+    assert rule.is_invalid_task_name(name) == expected
 
 
 class RoleTestCase(Base, common.RuleTestCase):
-    def test_30_task_has_invalid_name_pattern__ok__setenv(self):
-        self.lint(True, subdir='ng', pattern='0.yml', env=_ENV_PATCH)
+    def test_30_ok_cases_by_config(self):
+        self.lint(True, subdir='ng', pattern='0.yml', config=CNF_0)
 
 
 class CliTestCase(Base, common.CliTestCase):
-    def test_30_ok_cases__env(self):
-        self.lint(True, subdir='ng', pattern='0.yml', env=_ENV_PATCH)
+    def test_30_ok_cases_by_config(self):
+        self.lint(True, subdir='ng', pattern='0.yml', config=CNF_0)

--- a/tests/TestTasksFileHasValidNameRule.py
+++ b/tests/TestTasksFileHasValidNameRule.py
@@ -6,29 +6,49 @@
 # pylint: disable=missing-function-docstring
 """Test cases for the rule, TasksFileHasValidName.
 """
+import ansiblelint.config
+import pytest
+
 from rules import TasksFileHasValidNameRule as TT
 from tests import common
-
-
-_ENV_PATCH = {TT.ENV_VAR: r'\S+'}
-
-
-def clear_function(*_args):
-    """Function to clear caches."""
-    TT.filename_re.cache_clear()
 
 
 class Base:
     this_py: common.MaybeModNameT = __file__
     this_mod: common.MaybeModT = TT
-    clear_fn: common.MaybeCallableT = clear_function
+    rule_memoized = ['valid_name_re', 'is_invalid_filename']
+
+
+@pytest.mark.parametrize(
+    'path,name,unicode,expected',
+    [('tasks/main.yml', '', False, True),
+     ('tasks/incl/main.yml', '', False, True),
+     ('tasks/main-0.yml', '', False, False),
+     ('tasks/main .yml', '', False, False),
+     ('tasks/ng_１.yml', '', False, False),
+     ('tasks/ng_１.yml', r'^\w+\.ya?ml$', True, True),
+     ('tasks/ng-２.yml', '', False, False),
+     ('tasks/include/main-0.yml', r'\S+', False, True),
+     ]
+)
+def test_is_valid_filename(path, name, unicode, expected, monkeypatch):
+    if name:
+        monkeypatch.setitem(
+            ansiblelint.config.options.rules, TT.ID,
+            dict(name=name, unicode=unicode)
+        )
+    rule = common.get_rule_instance_by_module(Base.this_py, Base.this_mod)
+    assert rule.is_valid_filename(path) == expected
+
+
+CNF_0 = dict(name=r'.+', unicode=False)
 
 
 class RuleTestCase(Base, common.RuleTestCase):
-    def test_30_tasks_file_has_valid_name__ok__env(self):
-        self.lint(True, subdir='ng', pattern='0.yml', env=_ENV_PATCH)
+    def test_30_ng_cases_by_config(self):
+        self.lint(True, subdir='ng', pattern='0.yml', config=CNF_0)
 
 
 class CliTestCase(Base, common.CliTestCase):
-    def test_30_tasks_file_has_valid_name__ok__env(self):
-        self.lint(True, subdir='ng', pattern='0.yml', env=_ENV_PATCH)
+    def test_30_ng_cases_by_config(self):
+        self.lint(True, subdir='ng', pattern='0.yml', config=CNF_0)

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -10,9 +10,13 @@ from .testcases import (
     MaybeModNameT, MaybeModT, MaybeCallableT,
     RuleTestCase, CliTestCase
 )
+from .utils import (
+    get_rule_instance_by_module,
+)
 
 __all__ = [
     'TESTS_DIR', 'TESTS_RES_DIR', 'RULES_DIR', 'DEFAULT_RULES_DIR',
     'MaybeModNameT', 'MaybeModT', 'MaybeCallableT',
-    'RuleTestCase', 'CliTestCase'
+    'RuleTestCase', 'CliTestCase',
+    'get_rule_instance_by_module',
 ]

--- a/tests/common/runner.py
+++ b/tests/common/runner.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2020, 2021 Satoru SATOH <satoru.satoh@gmail.com>
 # SPDX-License-Identifier: MIT
 #
-# pylint: disable=too-few-public-methods
+# pylint: disable=invalid-name,too-few-public-methods
 """Common utility test routines and classes.
 """
 import pathlib
@@ -28,7 +28,11 @@ def list_rule_ids(*rdirs: str) -> typing.Iterator[str]:
         yield rule.id
 
 
-def get_collection(rule: typing.Optional[AnsibleLintRule] = None
+RuleOptionsT = typing.Optional[typing.Dict[str, typing.Any]]
+
+
+def get_collection(rule: typing.Optional[AnsibleLintRule] = None,
+                   rule_options: RuleOptionsT = None
                    ) -> RulesCollection:
     """
     Get RulesCollection instance with given rule registered.
@@ -44,6 +48,12 @@ def get_collection(rule: typing.Optional[AnsibleLintRule] = None
         collection = RulesCollection(rulesdirs=rulesdirs)
 
     if rule:
+        # Hack to force setting options.
+        if rule_options:
+            setattr(
+                ansiblelint.config.options, 'rules', {rule.id: rule_options}
+            )
+
         collection.register(rule)
 
     return collection

--- a/tests/common/test_runner.py
+++ b/tests/common/test_runner.py
@@ -24,19 +24,26 @@ def test_list_rule_ids(rdirs):
 
 
 @pytest.mark.parametrize(
-    'rule',
-    [DebugRule(),
-     None,
+    'rule,options',
+    [(DebugRule(), None),
+     (DebugRule(), dict(enabled=True)),
+     (None, None),
      ]
 )
-def test_get_collection(rule):
-    collection = TT.get_collection(rule)
+def test_get_collection(rule, options):
+    collection = TT.get_collection(rule, rule_options=options)
     assert isinstance(collection, ansiblelint.rules.RulesCollection)
 
     rules = list(collection)
     assert len(rules) > 0  # It has default rules even if `rule` is None.
 
     if rule:
-        assert any(r for r in collection if r.id == rule.id)
+        rules = [r for r in collection if r.id == rule.id]
+        assert len(rules) == 1
+
+        if options:
+            # pylint: disable=no-member
+            grops = TT.ansiblelint.config.options.rules[rule.id]
+            assert sorted(grops.items()) == sorted(options.items())
 
 # vim:sw=4:ts=4:et:

--- a/tests/common/testcases.py
+++ b/tests/common/testcases.py
@@ -35,12 +35,15 @@ class BaseTestCase(unittest.TestCase):
 
     initialized: bool = False
 
-    @classmethod
-    def clear(cls):
+    def clear(self):
         """Call clear function if it's callable.
         """
-        if cls.clear_fn and callable(cls.clear_fn):
-            cls.clear_fn()  # pylint: disable=not-callable
+        if not self.initialized:
+            return
+
+        self.rule.get_config.cache_clear()
+        if self.clear_fn and callable(self.clear_fn):
+            self.clear_fn()  # pylint: disable=not-callable
 
     def init(self):
         """Initialize.

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -59,4 +59,12 @@ def get_rule_instance_by_name(rule_module, rule_name):
                          f'in {rule_module!r}.')
     return rule_cls()
 
+
+def get_rule_instance_by_module(test_py: str, rule_module):
+    """
+    Get the rule instance by rule module's filename and module object.
+    """
+    rule_name = get_rule_name(test_py)
+    return get_rule_instance_by_name(rule_module, rule_name)
+
 # vim:sw=4:ts=4:et:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, devel
 skipsdist = true
 
 [gh-actions]
@@ -7,7 +7,7 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39
+    3.9: py39, devel
 
 [testenv]
 deps =
@@ -25,6 +25,12 @@ commands =
     - pylint --disable=invalid-name,locally-disabled rules
     mypy rules
     pytest
+
+[testenv:devel]
+deps =
+    ansible
+    -e git+https://github.com/ansible-community/ansible-lint@master#egg=ansible-lint
+    -r {toxinidir}/tests/requirements.txt
 
 [testenv:dists]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, devel
+envlist = py36, py37, py38, py39
 skipsdist = true
 
 [gh-actions]
@@ -7,7 +7,7 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39, devel
+    3.9: py39
 
 [testenv]
 deps =
@@ -25,12 +25,6 @@ commands =
     - pylint --disable=invalid-name,locally-disabled rules
     mypy rules
     pytest
-
-[testenv:devel]
-deps =
-    ansible
-    -e git+https://github.com/ansible-community/ansible-lint@master#egg=ansible-lint
-    -r {toxinidir}/tests/requirements.txt
 
 [testenv:dists]
 deps =


### PR DESCRIPTION
Because github.com/ansible-community/ansible-lint#1534 was merged, we now can configure each rule by its own configurations in .ansible-lint. This change utilizes that and eliminate hacks to configure rules by environment variables.