### PR TITLE
change: export common and duplicated code into functions in _utils

### DIFF
--- a/rules/_utils.py
+++ b/rules/_utils.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2020,2021 Satoru SATOH <satoru.satoh@gmail.com>
+# SPDX-License-Identifier: MIT
+#
+# pylint: disable=invalid-name
+"""Common utility functions.
+"""
+import re
+import typing
+import warnings
+
+if typing.TYPE_CHECKING:
+    import ansiblelint.rules
+
+
+C_NAME: str = 'name'
+C_UNICODE: str = 'unicode'
+
+
+def make_valid_name_pattern_from_rule_config(
+    rule: 'ansiblelint.rules.AnsibleLintRule',
+    default: typing.Pattern,
+    name_config_key: str = C_NAME,
+    unicode_config_key: str = C_UNICODE
+) -> typing.Pattern:
+    """Make a regexp pattern object to test given name is valid or not.
+    """
+    pattern_s = rule.get_config(name_config_key)
+    if pattern_s:
+        try:
+            if rule.get_config(unicode_config_key):
+                return re.compile(pattern_s)
+
+            return re.compile(pattern_s, re.ASCII)
+        except BaseException:  # pylint: disable=broad-except
+            warnings.warn(f'Invalid name pattern: "{pattern_s}"')
+
+    return default
+
+
+def is_valid_name(pattern: typing.Pattern, name: str) -> bool:
+    """
+    Test if given name is valid or not.
+    """
+    return pattern.match(name) is not None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,63 @@
+# Copyright (C) Satoru SATOH <satoru.satoh@gmail.com>
+# SPDX-License-Identifier: MIT
+#
+# pylint: disable=invalid-name
+# pylint: disable=too-few-public-methods,missing-class-docstring
+# pylint: disable=missing-function-docstring
+"""Test cases for libs.utils.
+"""
+import re
+import unittest.mock
+
+import pytest
+
+import ansiblelint.config
+import ansiblelint.rules
+
+from rules import _utils as TT
+
+
+class CustomRule(ansiblelint.rules.AnsibleLintRule):
+    id: str = 'custom-00'
+
+
+@pytest.mark.parametrize(
+    ('default', 'pattern', 'allow_unicode'),
+    ((None, None, True),
+     (None, None, False),
+     (None, '^.+$', True),
+     (None, '^.+$', False),
+     (None, '^\\w+$', False),
+     )
+)
+def test_make_valid_name_pattern_from_rule_config(
+    default, pattern, allow_unicode
+):
+    if pattern:
+        if allow_unicode:
+            exp = re.compile(pattern)
+        else:
+            exp = re.compile(pattern, re.ASCII)
+    else:
+        exp = default
+
+    with unittest.mock.patch.dict(
+        ansiblelint.config.options.rules,
+        {CustomRule.id: dict(name=pattern, unicode=allow_unicode)}
+    ):
+        res = TT.make_valid_name_pattern_from_rule_config(
+            CustomRule(), default
+        )
+        assert res == exp
+
+
+@pytest.mark.parametrize(
+    ('pattern', 'name', 'exp'),
+    ((re.compile('^.+$'), 'foo', True),
+     (re.compile('^\\S+$'), 'foo', True),
+     (re.compile('^\\S+$'), '   ', False),
+     (re.compile('^\\w+$'), 'foo', True),
+     )
+)
+def test_is_valid_name(pattern, name, exp):
+    assert TT.is_valid_name(pattern, name) == exp


### PR DESCRIPTION
Export common and duplicated code of the followings to a couple of
fucntions in _utils and add those test cases.

- rules/FileHasValidNameRule.py
- rules/TaskHasValidNameRule.py
- rules/TasksFileHasValidNameRule.py