### PR TITLE
enhancment: add an experimental rule to check variable names in vars files

### DIFF
--- a/rules/VarsInVarsFilesHaveValidNamesRule.py
+++ b/rules/VarsInVarsFilesHaveValidNamesRule.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2021 Satoru SATOH <satoru.satoh@gmail.com>
+# SPDX-License-Identifier: MIT
+#
+# pylint: disable=invalid-name
+"""Lint rule class to test if variables in vars files have valid names.
+"""
+import functools
+import re
+import typing
+import warnings
+
+import ansiblelint.rules
+import ansiblelint.utils
+
+if typing.TYPE_CHECKING:
+    from ansiblelint.constants import odict
+    from ansiblelint.errors import MatchError
+    from ansiblelint.file_utils import Lintable
+
+
+ID: str = 'vars_in_vars_files_have_valid_names'
+DESC: str = r"""Rule to test if variables in vars files have valid names.
+
+- Notes
+
+  - Variables files = {host_vars,group_vars,vars,defaults}/**/*.ya?ml
+  - .. seealso:: ansiblelint.config.DEFAULT_KINDS
+
+- Options
+
+  - ``name`` gives a valid task filename pattern (regexp)
+  - ``unicode`` allows unicode characters are used in filenames
+
+- Configuration
+
+  .. code-block:: yaml
+
+    rules:
+      tasks_file_has_valid_name:
+        name: ^\w+$
+        unicode: false
+"""
+C_NAME_RE: str = 'name'
+C_UNICODE: str = 'unicode'
+
+DEFAULT_NAME_RE: typing.Pattern = re.compile(r'^\w+$', re.ASCII)
+
+
+def each_keys(data: 'odict[str, typing.Any]') -> typing.Iterator[str]:
+    """
+    Traverse nested dict and yield keys.
+    """
+    for key, _val, _parent in ansiblelint.utils.nested_items(data):
+        # Special case.
+        # .. seealso:: ansiblelint.utils.nested_items
+        if key == 'list-item':
+            continue
+
+        yield key
+
+
+class VarsInVarsFilesHaveValidNamesRule(ansiblelint.rules.AnsibleLintRule):
+    """
+    Rule class to test if variables defined in vars files (host_vars,
+    group_vars, defaults, vars) have valid names follows the naming rules.
+    """
+    id = ID
+    shortdesc: str = 'Variable in vars files must have valid name'
+    description = DESC
+    severity = 'HIGH'
+    tags = ['idiom']
+
+    @functools.lru_cache(None)
+    def valid_name_re(self) -> typing.Pattern:
+        """A valid variable name pattern.
+        """
+        pattern_s = self.get_config(C_NAME_RE)
+        if pattern_s:
+            try:
+                if self.get_config(C_UNICODE):
+                    return re.compile(pattern_s)
+
+                return re.compile(pattern_s, re.ASCII)
+            except BaseException:  # pylint: disable=broad-except
+                warnings.warn(f'Invalid pattern "{pattern_s}"')
+
+        return DEFAULT_NAME_RE
+
+    @functools.lru_cache()
+    def is_invalid_name(self, var_name: str) -> bool:
+        """
+        True if given variable name is NOT valid.
+        """
+        return self.valid_name_re().match(var_name) is None
+
+    def matchplay(self, file: 'Lintable',
+                  data: 'odict[str, typing.Any]'
+                  ) -> typing.List['MatchError']:
+        """
+        .. seealso:; ansiblelint.rules.AnsibleLintRule.matchplay
+        """
+        if file.kind == 'vars':
+            return [
+                self.create_matcherror(
+                    details=f'{self.shortdesc}: {var_name}', filename=file
+                )
+                for var_name in each_keys(data)
+                if self.is_invalid_name(var_name)
+            ]
+
+        return []

--- a/tests/TestVarsInVarsFilesHaveValidNamesRule.py
+++ b/tests/TestVarsInVarsFilesHaveValidNamesRule.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2021 Satoru SATOH <satoru.satoh@gmail.com>
+# SPDX-License-Identifier: MIT
+#
+# pylint: disable=invalid-name
+# pylint: disable=missing-function-docstring,missing-class-docstring
+# pylint: disable=too-few-public-methods
+"""Test cases for the rule, VarsInVarsFilesHaveValidNamesRule.
+"""
+from rules import VarsInVarsFilesHaveValidNamesRule as TT
+from tests import common
+
+
+class Base(common.Base):
+    this_mod: common.MaybeModT = TT
+    default_skip_list = ['vars_should_not_be_used']
+
+
+class RuleTestCase(common.RuleTestCase):
+    base_cls = Base
+
+
+class CliTestCase(common.CliTestCase):
+    base_cls = Base

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/0/group_vars/localhost.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/0/group_vars/localhost.yml
@@ -1,0 +1,8 @@
+---
+フー:
+foo.bar: 1
+bar.bar:
+  baz:
+    - foo
+    - bar
+    - baz

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/0/playbook.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/0/playbook.yml
@@ -1,0 +1,1 @@
+../../ok/0/playbook.yml

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/playbook.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/playbook.yml
@@ -1,0 +1,1 @@
+../../ok/1/playbook.yml

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/roles/ping/defaults/main.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/roles/ping/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+foo.bar: 1
+bar.baz:
+  foo_bar_baz: aaa
+フー: FOO

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/roles/ping/tasks/assertions.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/roles/ping/tasks/assertions.yml
@@ -1,0 +1,16 @@
+---
+- name: Test variables are set
+  assert:
+    that:
+      - foo is defined
+      - foo is number
+      - foo > 0
+      - bar is defined
+      - bar is mapping
+      - bar | bool
+      - bar.baz is defined
+      - bar.baz is mapping
+      - bar.baz | bool
+      - bar.baz.foo_bar_baz is defined
+      - bar.baz.foo_bar_baz is string
+      - bar.baz.foo_bar_baz | bool

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/roles/ping/tasks/debug.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/roles/ping/tasks/debug.yml
@@ -1,0 +1,8 @@
+---
+- name: debug 1
+  debug:
+    var: foo
+
+- name: debug 2
+  debug:
+    var: bar.baz.foo_bar_baz

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/roles/ping/tasks/do_ping.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/roles/ping/tasks/do_ping.yml
@@ -1,0 +1,3 @@
+---
+- name: Try ping
+  ping:

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/roles/ping/tasks/main.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ng/1/roles/ping/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: include task 1
+  include_tasks: "assertions.yml"
+  vars:
+    foo: true
+    bar:
+      baz:
+        foo_bar_baz: BAZ
+
+- name: include task 2
+  include_tasks: "do_ping.yml"

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ok/0/group_vars/localhost.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ok/0/group_vars/localhost.yml
@@ -1,0 +1,8 @@
+---
+foo: 1
+bar:
+  bar:
+    baz:
+      - foo
+      - bar
+      - baz

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ok/0/playbook.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ok/0/playbook.yml
@@ -1,0 +1,1 @@
+../../../playbooks/plays_ok_0.yml

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ok/1/playbook.yml
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ok/1/playbook.yml
@@ -1,0 +1,1 @@
+../../../playbooks/ping_ok_1.yml

--- a/tests/res/VarsInVarsFilesHaveValidNamesRule/ok/1/roles/ping
+++ b/tests/res/VarsInVarsFilesHaveValidNamesRule/ok/1/roles/ping
@@ -1,0 +1,1 @@
+../../../../roles/ping_with_vars/


### PR DESCRIPTION
Add an experimental rule VarsInVarsFilesHaveValidNamesRule, to check
variable names in vars files under host_vars/, group_vars/, defaults/
and vars/, are valid, together with its test cases and test data.