### PR TITLE
Role arguments spec rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+.coverage
+.tox/
+*egg-info/

--- a/rules/NoUnspecifiedArgumentRule.py
+++ b/rules/NoUnspecifiedArgumentRule.py
@@ -8,12 +8,19 @@ import functools
 import re
 import typing
 import warnings
+import yaml
 
 import ansiblelint.rules
 
-from pathlib import Path
-from ansiblelint.utils import parse_yaml_from_file, nested_items
+from yaml.composer import Composer
+from yaml.constructor import Constructor
+from yaml.nodes import ScalarNode
+from yaml.resolver import BaseResolver
+from yaml.loader import SafeLoader
 
+from pathlib import Path
+from ansiblelint.utils import parse_yaml_linenumbers, parse_yaml_from_file, nested_items
+from ansiblelint.utils import LINE_NUMBER_KEY
 
 if typing.TYPE_CHECKING:
     from ansiblelint.constants import odict
@@ -41,38 +48,49 @@ DESC: str = r"""Rule to test if all role arguments are specified in meta/argumen
 def _lookup_argument_specs(var_file: Path, var_name: str) -> bool:
     """
     Find arg specification and lookup variable name is present.
-    """	
+    """
+    meta_data: Dict[str, Any] = {}
+
     if var_file.is_file():
-        argument_specs: Path = var_file.parent / ".." / "meta" / "argument_specs.yml"
-    print('lookup var_name = %s' % var_name )
-    if argument_specs.is_file():
-        meta_data = parse_yaml_from_file(str(argument_specs))
-        print(meta_data)
-        if meta_data:
-            try:
-            	if meta_data["argument_specs"]["main"]["options"]:
-                    return var_name in meta_data["argument_specs"]["main"]["options"]
-            except KeyError:
-                return False
+        argument_specs_path: Path = var_file.parent / ".." / "meta" / "argument_specs.yml"
+        argument_specs = str(argument_specs_path)
+
+    if argument_specs_path.is_file() and not argument_specs in meta_data.keys():
+        meta_data[argument_specs] = parse_yaml_from_file(argument_specs)
+
+    if argument_specs in meta_data.keys():
+        try:
+            if meta_data[argument_specs]["argument_specs"]["main"]["options"]:
+                return var_name in meta_data[argument_specs]["argument_specs"]["main"]["options"]
+        except KeyError:
+            return False
+
     return False
 
 
-def each_keys(data: 'odict[str, typing.Any]') -> typing.Iterator[str]:
-    """
-    Traverse nested dict and yield keys. 
-    todo: nested_items is deprecated
-    """
-    for key, _val, _parent in nested_items(data):
-        # Special cases.
-        # .. seealso:: ansiblelint.utils.nested_items
-        if key in ['list-item', '__line__', '__file__']:
-            continue
+class LineLoader(SafeLoader):
+    def __init__(self, stream):
+        super(LineLoader, self).__init__(stream)
 
-        if isinstance(_val, dict) or _parent:
-            continue
+    def compose_node(self, parent, index):
+        # the line number where the previous token has ended (plus empty lines)
+        line = self.line
+        node = Composer.compose_node(self, parent, index)
+        node.__line__ = line + 1
+        return node
 
-        print("==== key: %s  ==== val: %s  ==== par: %s" % (key, _val, _parent))
-        yield key, _parent+'.' if _parent else ''
+    def construct_mapping(self, node, deep=False):
+        node_pair_lst = node.value
+        node_pair_lst_for_appending = []
+
+        for key_node, value_node in node_pair_lst:
+            shadow_key_node = ScalarNode(tag=BaseResolver.DEFAULT_SCALAR_TAG, value='__line__' + key_node.value)
+            shadow_value_node = ScalarNode(tag=BaseResolver.DEFAULT_SCALAR_TAG, value=key_node.__line__)
+            node_pair_lst_for_appending.append((shadow_key_node, shadow_value_node))
+
+        node.value = node_pair_lst + node_pair_lst_for_appending
+        mapping = Constructor.construct_mapping(self, node, deep=deep)
+        return mapping
 
 
 class NoUnspecifiedArgumentRule(ansiblelint.rules.AnsibleLintRule):
@@ -86,20 +104,20 @@ class NoUnspecifiedArgumentRule(ansiblelint.rules.AnsibleLintRule):
     severity = 'HIGH'
     tags = [ID,'metadata','readability']
 
-    def matchplay(self, file: 'Lintable',
-                  data: 'odict[str, typing.Any]'
-                  ) -> typing.List['MatchError']:
-        """
-        .. seealso:; ansiblelint.rules.AnsibleLintRule.matchplay
-        """
-        if file.kind == 'vars':
-            print('data: %s' % data)
-            return [
-                self.create_matcherror(
-                    details=f'{self.shortdesc}: {parent}{var_name}', filename=file
-                )
-                for var_name, parent in each_keys(data)
-                if not _lookup_argument_specs(file.path, var_name)
-            ]
+    def matchyaml(self, file: 'Lintable') -> typing.List['MatchError']:
+        """Return matches for variables defined in vars files with no specification."""
+        results: List["MatchError"] = []
 
-        return []
+        if file.kind == 'vars':
+            with open(str(file.path), 'r') as f:
+                variables = yaml.load(f, Loader=LineLoader)
+                for var_name in filter(lambda k: not k.startswith('__line__') and not isinstance(variables[k],dict), variables.keys()):
+                    if not _lookup_argument_specs(file.path, var_name):
+                        results.append(
+                            self.create_matcherror(
+                                details=f'{self.shortdesc}: {var_name}', filename=file, linenumber=variables["__line__"+var_name]
+                            )
+                        )
+        else:
+            results.extend(super().matchyaml(file))
+        return results

--- a/rules/NoUnspecifiedArgumentRule.py
+++ b/rules/NoUnspecifiedArgumentRule.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2022 Guido Grazioli <guido.grazioli@gmail.com>
+# SPDX-License-Identifier: MIT
+#
+# pylint: disable=invalid-name
+"""Lint rule class to test if all role arguments are specified in meta/argument_specs.yml
+"""
+import functools
+import re
+import typing
+import warnings
+
+import ansiblelint.rules
+
+from pathlib import Path
+from ansiblelint.utils import parse_yaml_from_file, nested_items
+
+
+if typing.TYPE_CHECKING:
+    from ansiblelint.constants import odict
+    from ansiblelint.errors import MatchError
+    from ansiblelint.file_utils import Lintable
+
+
+ID: str = 'no_unspecified_argument'
+SHORTDESC: str = 'All role parameters must have a specification'
+DESC: str = r"""Rule to test if all role arguments are specified in meta/argument_specs.yml.
+
+- Notes
+
+  - Argument files = roles/**/{vars,defaults}/**/*.ya?ml
+  - .. seealso:: ansiblelint.config.DEFAULT_KINDS
+
+- Configuration
+
+  .. code-block:: yaml
+
+    rules:
+      no_unspecified_argument:
+"""
+
+def _lookup_argument_specs(var_file: Path, var_name: str) -> bool:
+    """
+    Find arg specification and lookup variable name is present.
+    """	
+    if var_file.is_file():
+        argument_specs: Path = var_file.parent / ".." / "meta" / "argument_specs.yml"
+    print('lookup var_name = %s' % var_name )
+    if argument_specs.is_file():
+        meta_data = parse_yaml_from_file(str(argument_specs))
+        print(meta_data)
+        if meta_data:
+            try:
+            	if meta_data["argument_specs"]["main"]["options"]:
+                    return var_name in meta_data["argument_specs"]["main"]["options"]
+            except KeyError:
+                return False
+    return False
+
+
+def each_keys(data: 'odict[str, typing.Any]') -> typing.Iterator[str]:
+    """
+    Traverse nested dict and yield keys. 
+    todo: nested_items is deprecated
+    """
+    for key, _val, _parent in nested_items(data):
+        # Special cases.
+        # .. seealso:: ansiblelint.utils.nested_items
+        if key in ['list-item', '__line__', '__file__']:
+            continue
+
+        if isinstance(_val, dict) or _parent:
+            continue
+
+        print("==== key: %s  ==== val: %s  ==== par: %s" % (key, _val, _parent))
+        yield key, _parent+'.' if _parent else ''
+
+
+class NoUnspecifiedArgumentRule(ansiblelint.rules.AnsibleLintRule):
+    """
+    Rule class to test if all role parameters (defaults, vars) have 
+    a format specification in meta/argument_specs.yml.
+    """
+    id = ID
+    shortdesc = SHORTDESC
+    description = DESC
+    severity = 'HIGH'
+    tags = [ID,'metadata','readability']
+
+    def matchplay(self, file: 'Lintable',
+                  data: 'odict[str, typing.Any]'
+                  ) -> typing.List['MatchError']:
+        """
+        .. seealso:; ansiblelint.rules.AnsibleLintRule.matchplay
+        """
+        if file.kind == 'vars':
+            print('data: %s' % data)
+            return [
+                self.create_matcherror(
+                    details=f'{self.shortdesc}: {parent}{var_name}', filename=file
+                )
+                for var_name, parent in each_keys(data)
+                if not _lookup_argument_specs(file.path, var_name)
+            ]
+
+        return []

--- a/tests/TestBlockedModules.py
+++ b/tests/TestBlockedModules.py
@@ -12,7 +12,7 @@ from tests import common
 
 class Base(common.Base):
     this_mod: common.MaybeModT = TT
-
+    default_skip_list = ['no_unspecified_argument']
 
 class RuleTestCase(common.RuleTestCase):
     base_cls = Base

--- a/tests/TestDebugRule.py
+++ b/tests/TestDebugRule.py
@@ -29,6 +29,7 @@ def test_is_enabled(env, exp):
 
 class Base(common.Base):
     this_mod: common.MaybeModT = TT
+    default_skip_list = ['no_unspecified_argument']
 
 
 class RuleTestCase(common.RuleTestCase):

--- a/tests/TestFileHasValidNameRule.py
+++ b/tests/TestFileHasValidNameRule.py
@@ -46,6 +46,7 @@ def test_is_invalid_filename(path, name, unicode, expected, monkeypatch):
 
 class Base(common.Base):
     this_mod: common.MaybeModT = TT
+    default_skip_list = ['no_unspecified_argument']
 
 
 class RuleTestCase(common.RuleTestCase):

--- a/tests/TestFileIsSmallEnoughRule.py
+++ b/tests/TestFileIsSmallEnoughRule.py
@@ -24,6 +24,7 @@ def test_exceeds_max_lines(max_lines, expected):
 
 class Base(common.Base):
     this_mod: common.MaybeModT = TT
+    default_skip_list = ['no_unspecified_argument']
 
 
 class RuleTestCase(common.RuleTestCase):

--- a/tests/TestNoEmptyDataFilesRule.py
+++ b/tests/TestNoEmptyDataFilesRule.py
@@ -30,6 +30,7 @@ def test_yml_file_has_some_data(content, expected, tmp_path):
 
 class Base(common.Base):
     this_mod: common.MaybeModT = TT
+    default_skip_list = ['no_unspecified_argument']
 
 
 class RuleTestCase(common.RuleTestCase):

--- a/tests/TestNoUnspecifiedArgumentRule.py
+++ b/tests/TestNoUnspecifiedArgumentRule.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2022 Guido Grazioli <guido.grazioli@gmail.com>
+# SPDX-License-Identifier: MIT
+#
+# pylint: disable=invalid-name
+# pylint: disable=too-few-public-methods,missing-class-docstring
+# pylint: disable=missing-function-docstring
+"""Test cases for the rule, NoUnspecifiedArgumentRule.
+"""
+import pytest
+
+from rules import NoUnspecifiedArgumentRule as TT
+from tests import common
+
+
+RES_DIR = common.TESTS_RES_DIR / 'NoUnspecifiedArgumentRule'
+
+
+class Base(common.Base):
+    this_mod: common.MaybeModT = TT
+
+
+class RuleTestCase(common.RuleTestCase):
+    base_cls = Base
+
+
+class CliTestCase(common.CliTestCase):
+    base_cls = Base
+
+
+@pytest.mark.parametrize(
+    ('path', 'varname', 'expected'),
+    (
+        (RES_DIR / 'ok/0/playbook.yml', "ping_default_var", True),
+        (RES_DIR / 'ng/0/playbook.yml', "ping_default_var", False),
+    )
+)
+def test_lookup_argument_specs(path, varname, expected):
+	TT._lookup_argument_specs(path, varname)

--- a/tests/TestTaskHasValidNameRule.py
+++ b/tests/TestTaskHasValidNameRule.py
@@ -41,6 +41,7 @@ def test_is_invalid_task_name(name, evalue, expected, monkeypatch):
 
 class Base(common.Base):
     this_mod: common.MaybeModT = TT
+    default_skip_list = ['no_unspecified_argument']
 
 
 class RuleTestCase(common.RuleTestCase):

--- a/tests/TestTasksFileHasValidNameRule.py
+++ b/tests/TestTasksFileHasValidNameRule.py
@@ -15,7 +15,7 @@ from tests import common
 
 class Base(common.Base):
     this_mod: common.MaybeModT = TT
-    default_skip_list = ['file_has_valid_name']
+    default_skip_list = ['file_has_valid_name','no_unspecified_argument']
 
 
 class RuleTestCase(common.RuleTestCase):

--- a/tests/TestVarsInVarsFilesHaveValidNamesRule.py
+++ b/tests/TestVarsInVarsFilesHaveValidNamesRule.py
@@ -12,7 +12,7 @@ from tests import common
 
 class Base(common.Base):
     this_mod: common.MaybeModT = TT
-    default_skip_list = ['vars_should_not_be_used']
+    default_skip_list = ['vars_should_not_be_used','no_unspecified_argument']
 
 
 class RuleTestCase(common.RuleTestCase):

--- a/tests/res/NoUnspecifiedArgumentRule/ng/0/playbook.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ng/0/playbook.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - ping

--- a/tests/res/NoUnspecifiedArgumentRule/ng/0/roles/ping/defaults/main.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ng/0/roles/ping/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+ping_default_var: 'pong'

--- a/tests/res/NoUnspecifiedArgumentRule/ng/0/roles/ping/meta/argument_specs.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ng/0/roles/ping/meta/argument_specs.yml
@@ -1,0 +1,4 @@
+---
+argument_specs:
+  main:
+    options:

--- a/tests/res/NoUnspecifiedArgumentRule/ng/0/roles/ping/vars/main.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ng/0/roles/ping/vars/main.yml
@@ -1,0 +1,7 @@
+---
+ping_required_var:
+
+# internal dict variable
+ping_config:
+  home: '/opt'
+  enabled: yes

--- a/tests/res/NoUnspecifiedArgumentRule/ng/1/playbook.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ng/1/playbook.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - ping

--- a/tests/res/NoUnspecifiedArgumentRule/ng/1/roles/ping/defaults/main.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ng/1/roles/ping/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+ping_default_var: 'pong'

--- a/tests/res/NoUnspecifiedArgumentRule/ng/1/roles/ping/vars/main.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ng/1/roles/ping/vars/main.yml
@@ -1,0 +1,7 @@
+---
+ping_required_var:
+
+# internal dict variable
+ping_config:
+  home: '/opt'
+  enabled: yes

--- a/tests/res/NoUnspecifiedArgumentRule/ok/0/playbook.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ok/0/playbook.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  roles:
+    - ping

--- a/tests/res/NoUnspecifiedArgumentRule/ok/0/roles/ping/defaults/main.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ok/0/roles/ping/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+ping_default_var: 'pong'

--- a/tests/res/NoUnspecifiedArgumentRule/ok/0/roles/ping/meta/argument_specs.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ok/0/roles/ping/meta/argument_specs.yml
@@ -1,0 +1,13 @@
+---
+argument_specs:
+  main:
+    options:
+      ping_required_var:
+        type: "str"
+        required: true
+        description: "A required string variable."
+      ping_default_var:
+        type: "str"
+        required: false
+        default: 'pong'
+        description: "A string parameter with default."  

--- a/tests/res/NoUnspecifiedArgumentRule/ok/0/roles/ping/vars/main.yml
+++ b/tests/res/NoUnspecifiedArgumentRule/ok/0/roles/ping/vars/main.yml
@@ -1,0 +1,7 @@
+---
+ping_required_var:
+
+# internal dict variable
+ping_config:
+  home: '/opt'
+  enabled: yes


### PR DESCRIPTION
This rule is meant to lint roles arguments in collections, facilitating role reuse.

For each root-level non-dict role variable parsed  in var-files for a role (ie. `defaults|vars/*.ya?ml`), it checks its declaration is present in `meta/argument_specs.yml`. 

See: https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#specification-format